### PR TITLE
fields documented as conditionally present are listed in "required"

### DIFF
--- a/json/ChangeDimensionPacketPayload.json
+++ b/json/ChangeDimensionPacketPayload.json
@@ -29,7 +29,6 @@
     },
     "required": [
         "Dimension ID",
-        "Loading Screen Id",
         "Position",
         "Respawn"
     ]

--- a/json/ServerboundLoadingScreenPacketPayload.json
+++ b/json/ServerboundLoadingScreenPacketPayload.json
@@ -28,7 +28,6 @@
         }
     },
     "required": [
-        "Loading Screen Id",
         "Loading Screen Packet Type"
     ]
 }


### PR DESCRIPTION
The primitives page (https://mojang.github.io/bedrock-protocol-docs/latest/primitives/) says an optional field starts with a presence byte, 0x00 meaning no value follows. A field in `required` doesn't have one, so it can't be both. These two are.

ChangeDimensionPacketPayload.json, "Loading Screen Id" on r/26_u4_hotfix5:

> Leave empty if there is no loading screen expected on the client. This id needs to be unique and not conflict with any other active loading screens.  This is implemented with an unsigned integer incrementing forever, and that is expected to not have collisions when it wraps around back to 0 if that could be a possibility.

It's in `required`. And since the counter wraps back to 0, that's a real id, not a "none" value, so a plain uint32 couldn't express "no loading screen" at all.

ServerboundLoadingScreenPacketPayload.json, "Loading Screen Id", same branch:

> This will be set if the server gives us a value. If the server doesn't expect this value, then the client will get disconnected.

Also in `required`.

A generator reading `required` writes the value without the presence byte and gets the payload length wrong.

Those descriptions only exist on r/26_u4_hotfix5, which is why the diff here doesn't show them. That branch has 238 described fields out of 720, main has 0 out of 725.

If these are generated upstream and this would just get overwritten, close it and treat it as a bug report.

ps: sorry if some parties don’t have a sense, these are texts translated from French to English :)